### PR TITLE
Add Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,19 @@ Setup:
 uv sync
 ```
 
-Run backend server:
+Run backend server on Linux:
 
 ```
 ./scripts/server.sh
 ```
 
+Run backend server on Windows:
+
+```
+./scripts/server.bat
+```
+
+Note: `scripts/server.sh` is for Linux and `scripts/server.bat` is for Windows.
 
 ## Frontend server
 
@@ -31,4 +38,3 @@ Run frontend server:
 ```
 bun dev
 ```
-

--- a/scripts/server.bat
+++ b/scripts/server.bat
@@ -1,0 +1,3 @@
+@echo off
+call .venv\Scripts\activate
+python server.py


### PR DESCRIPTION
Fixes #1

Add support for running the server on Windows.

* **New Script**: Add `scripts/server.bat` to run the server on Windows.
* **README Update**: Update `README.md` to include instructions for running the server on Windows using `scripts/server.bat`. Add a note that `scripts/server.sh` is for Linux and `scripts/server.bat` is for Windows.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/p1atdev/danbooru-tags-translator-web-app/pull/2?shareId=9a6da2a9-805e-41b6-95a0-c41f54614483).