### PR TITLE
Update README files with tool explanations and Japanese translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,54 @@
 # Danbooru Tags Translator Web App
 
+[English version](./README_EN.md)
+
+
 ![](./assets/screenshot.jpg)
 
-## Backend server
+## バックエンドサーバー
 
-Setup:
+`uv` (https://docs.astral.sh/uv/) を使用して環境を構築できます。
+
+セットアップ:
 
 ```
 uv sync
 ```
 
-Run backend server on Linux:
+
+
+Linux でバックエンドサーバーを実行:
 
 ```
 ./scripts/server.sh
 ```
 
-Run backend server on Windows:
+Windows でバックエンドサーバーを実行:
 
 ```
 ./scripts/server.bat
 ```
 
-Note: `scripts/server.sh` is for Linux and `scripts/server.bat` is for Windows.
+注: `scripts/server.sh` は Linux 用、`scripts/server.bat` は Windows 用です。
 
-## Frontend server
+## フロントエンドサーバー
 
-Setup:
+
+Bun (https://bun.sh/) の使用を推奨しますが、お好みで npm などを使っても大丈夫です。
+
+
+セットアップ:
 
 ```
 cd frontend
 bun i
 ```
 
-Run frontend server:
+
+
+フロントエンドサーバーを実行:
 
 ```
 bun dev
 ```
+


### PR DESCRIPTION
Translate `README.md` to Japanese and add explanations for `uv` and `bun` commands.

* Add a link to the English version of `README.md`.
* Add explanation for `uv` command in the backend server setup section.
* Add explanation for `bun` command in the frontend server setup section.
* Translate setup and run instructions for backend and frontend servers to Japanese.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/p1atdev/danbooru-tags-translator-web-app/pull/3?shareId=2cb997d6-a843-41e2-9ab0-5ee2b20d41b6).